### PR TITLE
Updated codesignature and pattern

### DIFF
--- a/MonoFramework/MonoFramework.download.recipe
+++ b/MonoFramework/MonoFramework.download.recipe
@@ -15,7 +15,7 @@ For universal 32bit/64bit build use MONOPATTERN (http.*universal.pkg)
         <key>NAME</key>
         <string>MonoFramework</string>
         <key>MONOPATTERN</key>
-        <string>(http.*.pkg)</string>
+        <string>(https.*.pkg)</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.4.0</string>
@@ -54,7 +54,7 @@ For universal 32bit/64bit build use MONOPATTERN (http.*universal.pkg)
                 <string>%pathname%</string>
                 <key>expected_authority_names</key>
                 <array>
-                    <string>Developer ID Installer: Xamarin Inc</string>
+                    <string>Developer ID Installer: Xamarin Inc (7V723M9SQ5)</string>
                     <string>Developer ID Certification Authority</string>
                     <string>Apple Root CA</string>
                 </array>

--- a/MonoFramework/MonoFramework.install.recipe
+++ b/MonoFramework/MonoFramework.install.recipe
@@ -15,7 +15,7 @@ For universal 32bit/64bit build use MONOPATTERN (http.*universal.pkg)
         <key>NAME</key>
         <string>MonoFramework</string>
         <key>MONOPATTERN</key>
-        <string>(http.*x86.pkg)</string>
+        <string>(https.*.pkg)</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.4.0</string>

--- a/MonoFramework/MonoFramework.munki.recipe
+++ b/MonoFramework/MonoFramework.munki.recipe
@@ -15,7 +15,7 @@ For universal 32bit/64bit build use MONOPATTERN (http.*universal.pkg)
         <key>NAME</key>
         <string>MonoFramework</string>
         <key>MONOPATTERN</key>
-        <string>(http.*x86.pkg)</string>
+        <string>(https.*.pkg)</string>
         <key>MUNKI_REPO_SUBDIR</key>
         <string>apps/developer/%NAME%</string>
         <key>pkginfo</key>

--- a/MonoFramework/README.md
+++ b/MonoFramework/README.md
@@ -4,5 +4,4 @@
 
 ## Notes
 
-- 32 bit version link looks like this: `http://download.mono-project.com/archive/4.2.3/macos-10-x86/MonoFramework-MDK-4.2.3.4.macos10.xamarin.x86.pkg`
-- Universal 32bit/64bit version link looks like this: `http://download.mono-project.com/archive/4.2.1/macos-10-universal/MonoFramework-MDK-4.2.1.102.macos10.xamarin.universal.pkg`
+- Universal 32bit/64bit version link looks like this: `https://download.mono-project.com/archive/4.8.1/macos-10-universal/MonoFramework-MDK-4.8.1.0.macos10.xamarin.universal.pkg`


### PR DESCRIPTION
Howdy,

I've updated the CodeSignature to match the latest used by the Mono-Project.
Also they've moved to using https and don't use x86/64 in their filename. Updated the patterns and changed the README. I believe they only offer universal version now.

Please accept my changes.

Your humble servant, Frank