### PR TITLE
new developer ID, again

### DIFF
--- a/MonoFramework/MonoFramework.download.recipe
+++ b/MonoFramework/MonoFramework.download.recipe
@@ -54,7 +54,7 @@ For universal 32bit/64bit build use MONOPATTERN (http.*universal.pkg)
                 <string>%pathname%</string>
                 <key>expected_authority_names</key>
                 <array>
-                    <string>Developer ID Installer: Xamarin Inc (7V723M9SQ5)</string>
+                    <string>Developer ID Installer: Microsoft Corporation (UBF8T346G9)</string>
                     <string>Developer ID Certification Authority</string>
                     <string>Apple Root CA</string>
                 </array>


### PR DESCRIPTION
Good afternoon,

.. just updated the developer ID for the SignatureVerifier

at the Mono team they changed their dev ID again. They new major version was updated to 5, so maybe that's why.

kind regards,
Frank