### PR TITLE
Use dmg for MacPass installer instead of pkg

### DIFF
--- a/MacPass/MacPass.munki.recipe
+++ b/MacPass/MacPass.munki.recipe
@@ -37,16 +37,27 @@
     <key>MinimumVersion</key>
     <string>0.5.0</string>
     <key>ParentRecipe</key>
-    <string>com.github.michalmmac.pkg.MacPass</string>
+    <string>com.github.michalmmac.download.MacPass</string>
     <key>Process</key>
     <array>
+        <dict>
+            <key>Processor</key>
+            <string>DmgCreator</string>
+            <key>Arguments</key>
+            <dict>
+                <key>dmg_path</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%-%version%.dmg</string>
+                <key>dmg_root</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%</string>
+            </dict>
+        </dict>
         <dict>
             <key>Processor</key>
             <string>MunkiImporter</string>
             <key>Arguments</key>
             <dict>
                 <key>pkg_path</key>
-                <string>%pkg_path%</string>
+                <string>%dmg_path%</string>
                 <key>repo_subdirectory</key>
                 <string>%MUNKI_REPO_SUBDIR%</string>
             </dict>


### PR DESCRIPTION
Follow up to https://github.com/autopkg/MichalMMac-recipes/pull/12 to ensure Munki blocking apps are not needed.