### PR TITLE
Deprecate RocketChat recipes

### DIFF
--- a/RocketChat/RocketChat.download.recipe
+++ b/RocketChat/RocketChat.download.recipe
@@ -19,6 +19,15 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Consider switching to the RocketChatClient recipes in the apizz-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>URLTextSearcher</string>
             <key>Arguments</key>
             <dict>


### PR DESCRIPTION
This PR deprecates the non-functional RocketChat recipes in this repo, and points users to the working equivalents in the apizz-recipes repo.
