### PR TITLE
Change parent of draw.io munki/install recipe, deprecate download recipe

### DIFF
--- a/draw.io/draw.io.download.recipe
+++ b/draw.io/draw.io.download.recipe
@@ -22,6 +22,15 @@ for arm change %PLATFORM_ARCH% AND %SUPPORTED_ARCH% to arm64</string>
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Consider switching to the draw.io recipes in the peshay-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>GitHubReleasesInfoProvider</string>
             <key>Arguments</key>
             <dict>

--- a/draw.io/draw.io.install.recipe
+++ b/draw.io/draw.io.install.recipe
@@ -14,7 +14,7 @@
     <key>MinimumVersion</key>
     <string>2.0</string>
     <key>ParentRecipe</key>
-    <string>com.github.michalmmac.download.draw.io</string>
+    <string>com.github.peshay.download.draw.io</string>
     <key>Process</key>
     <array>
        <dict>

--- a/draw.io/draw.io.munki.recipe
+++ b/draw.io/draw.io.munki.recipe
@@ -45,7 +45,7 @@
     <key>MinimumVersion</key>
     <string>2.0</string>
     <key>ParentRecipe</key>
-    <string>com.github.michalmmac.download.draw.io</string>
+    <string>com.github.peshay.download.draw.io</string>
     <key>Process</key>
     <array>
         <dict>

--- a/draw.io/draw.io.munki.recipe
+++ b/draw.io/draw.io.munki.recipe
@@ -11,7 +11,7 @@
         <key>NAME</key>
         <string>draw.io</string>
         <key>MUNKI_REPO_SUBDIR</key>
-        <string>apps/productivity/%NAME%_%PLATFORM_ARCH%</string>
+        <string>apps/productivity/%NAME%</string>
         <key>pkginfo</key>
         <dict>
             <key>catalogs</key>
@@ -27,7 +27,7 @@
             <key>display_name</key>
             <string>%NAME%</string>
             <key>name</key>
-            <string>%NAME%_%PLATFORM_ARCH%</string>
+            <string>%NAME%</string>
             <key>minimum_os_version</key>
             <string>10.7.0</string>
             <key>blocking_applications</key>
@@ -36,10 +36,6 @@
             </array>
             <key>unattended_install</key>
             <true/>
-            <key>supported_architectures</key>
-            <array>
-                <string>%SUPPORTED_ARCH%</string>
-            </array>
         </dict>
     </dict>
     <key>MinimumVersion</key>


### PR DESCRIPTION
This PR changes the parent recipe for the draw.io munki and install recipes to the download recipe in peshay-recipes, and deprecates the download recipe in this repo.

The munki recipe has also had references to the PLATFORM_ARCH variable removed, since the parent download recipe supplies a universal installer.

Verbose recipe run output for munki recipe:

```
% autopkg run -vvq draw.io.munki.recipe
Processing draw.io.munki.recipe...
WARNING: draw.io.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
GitHubReleasesInfoProvider
{'Input': {'asset_regex': '(draw.io-universal-.*?\\.dmg)$',
           'github_repo': 'jgraph/drawio-desktop'}}
GitHubReleasesInfoProvider: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
GitHubReleasesInfoProvider: No value supplied for GITHUB_URL, setting default value of: https://api.github.com
GitHubReleasesInfoProvider: No value supplied for GITHUB_TOKEN_PATH, setting default value of: ~/.autopkg_gh_token
GitHubReleasesInfoProvider: Matched regex '(draw.io-universal-.*?\.dmg)$' among asset(s): draw.io-25.0.2-windows-installer.exe, draw.io-25.0.2-windows-installer.exe.blockmap, draw.io-25.0.2-windows-no-installer.exe, draw.io-25.0.2.msi, draw.io-arm64-25.0.2-windows-arm64-installer.exe, draw.io-arm64-25.0.2-windows-arm64-installer.exe.blockmap, draw.io-arm64-25.0.2-windows-arm64-no-installer.exe, draw.io-arm64-25.0.2.dmg, draw.io-arm64-25.0.2.dmg.blockmap, draw.io-arm64-25.0.2.zip, draw.io-arm64-25.0.2.zip.blockmap, draw.io-ia32-25.0.2-windows-32bit-installer.exe, draw.io-ia32-25.0.2-windows-32bit-installer.exe.blockmap, draw.io-ia32-25.0.2-windows-32bit-no-installer.exe, draw.io-universal-25.0.2.dmg, draw.io-universal-25.0.2.dmg.blockmap, draw.io-x64-25.0.2.dmg, draw.io-x64-25.0.2.dmg.blockmap, draw.io-x64-25.0.2.zip, draw.io-x64-25.0.2.zip.blockmap, drawio-aarch64-25.0.2.rpm, drawio-amd64-25.0.2.deb, drawio-arm64-25.0.2.AppImage, drawio-arm64-25.0.2.deb, drawio-x86_64-25.0.2.AppImage, drawio-x86_64-25.0.2.rpm, latest-linux-arm64.yml, latest-linux.yml, latest-mac.yml, latest.yml
GitHubReleasesInfoProvider: Selected asset 'draw.io-universal-25.0.2.dmg' from release '25.0.2'
{'Output': {'asset_created_at': '2024-12-03T11:28:54Z',
            'asset_url': 'https://api.github.com/repos/jgraph/drawio-desktop/releases/assets/210719593',
            'release_notes': '## Releases Notes for 25.0.2\r\n'
                             '[Windows '
                             'Installer](https://github.com/jgraph/drawio-desktop/releases/download/v25.0.2/draw.io-25.0.2-windows-installer.exe)\r\n'
                             '[Windows No '
                             'Installer](https://github.com/jgraph/drawio-desktop/releases/download/v25.0.2/draw.io-25.0.2-windows-no-installer.exe)\r\n'
                             '[macOS - '
                             'Universal](https://github.com/jgraph/drawio-desktop/releases/download/v25.0.2/draw.io-universal-25.0.2.dmg)\r\n'
                             'Linux - '
                             '[deb](https://github.com/jgraph/drawio-desktop/releases/download/v25.0.2/drawio-amd64-25.0.2.deb), '
                             '[AppImage](https://github.com/jgraph/drawio-desktop/releases/download/v25.0.2/drawio-x86_64-25.0.2.AppImage) '
                             'or '
                             '[rpm](https://github.com/jgraph/drawio-desktop/releases/download/v25.0.2/drawio-x86_64-25.0.2.rpm)\r\n'
                             '\r\n'
                             'Windows intel x32 releases are marked -ia32-\r\n'
                             '\r\n'
                             '**ChangeLog:**\r\n'
                             '\r\n'
                             '- #1922 \r\n'
                             '- Updates to draw.io core 25.0.2\r\n'
                             '- Uses electron 32.2.5\r\n'
                             '- Updates to [draw.io core '
                             '25.0.2](https://github.com/jgraph/drawio/blob/v25.0.2/ChangeLog). '
                             'All changes from 25.0.2 are added in this build.',
            'url': 'https://github.com/jgraph/drawio-desktop/releases/download/v25.0.2/draw.io-universal-25.0.2.dmg',
            'version': '25.0.2'}}
URLDownloader
{'Input': {'url': 'https://github.com/jgraph/drawio-desktop/releases/download/v25.0.2/draw.io-universal-25.0.2.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.michalmmac.munki.draw.io/downloads/draw.io-universal-25.0.2.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.michalmmac.munki.draw.io/downloads/draw.io-universal-25.0.2.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.michalmmac.munki.draw.io/downloads/draw.io-universal-25.0.2.dmg/draw.io.app',
           'requirement': 'identifier "com.jgraph.drawio.desktop" and anchor '
                          'apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'UZEUFB4N53'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.michalmmac.munki.draw.io/downloads/draw.io-universal-25.0.2.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.MXOWOo/draw.io.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.MXOWOo/draw.io.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.MXOWOo/draw.io.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
MunkiImporter
{'Input': {'MUNKI_REPO': '/Users/Shared/munki_repo',
           'pkg_path': '~/Library/AutoPkg/Cache/com.github.michalmmac.munki.draw.io/downloads/draw.io-universal-25.0.2.dmg',
           'pkginfo': {'blocking_applications': ['draw.io'],
                       'catalogs': ['testing'],
                       'category': 'Productivity',
                       'description': 'diagrams.net is open source, online, '
                                      'desktop and container deployable '
                                      'diagramming software',
                       'developer': 'diagrams.net',
                       'display_name': 'draw.io',
                       'minimum_os_version': '10.7.0',
                       'name': 'draw.io',
                       'unattended_install': True},
           'repo_subdirectory': 'apps/productivity/draw.io'}}
MunkiImporter: No value supplied for MUNKI_REPO_PLUGIN, setting default value of: FileRepo
MunkiImporter: No value supplied for MUNKILIB_DIR, setting default value of: /usr/local/munki
MunkiImporter: No value supplied for force_munki_repo_lib, setting default value of: False
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/productivity/draw.io/draw.io-25.0.2.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/productivity/draw.io/draw.io-universal-25.0.2.dmg
{'Output': {'munki_importer_summary_result': {'data': {'catalogs': 'testing',
                                                       'icon_repo_path': '',
                                                       'name': 'draw.io',
                                                       'pkg_repo_path': 'apps/productivity/draw.io/draw.io-universal-25.0.2.dmg',
                                                       'pkginfo_path': 'apps/productivity/draw.io/draw.io-25.0.2.plist',
                                                       'version': '25.0.2'},
                                              'report_fields': ['name',
                                                                'version',
                                                                'catalogs',
                                                                'pkginfo_path',
                                                                'pkg_repo_path',
                                                                'icon_repo_path'],
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'imported into '
                                                              'Munki:'},
            'munki_info': {'_metadata': {'created_by': 'testuser',
                                         'creation_date': datetime.datetime(2025, 1, 1, 20, 5, 39),
                                         'munki_version': '6.6.3.4704',
                                         'os_version': '15.2'},
                           'autoremove': False,
                           'blocking_applications': ['draw.io'],
                           'catalogs': ['testing'],
                           'category': 'Productivity',
                           'description': 'diagrams.net is open source, '
                                          'online, desktop and container '
                                          'deployable diagramming software',
                           'developer': 'diagrams.net',
                           'display_name': 'draw.io',
                           'installer_item_hash': 'ab9c5bcea90ca3080fbc0f4195b768475a4acb17a2bf541b892dd259aac81559',
                           'installer_item_location': 'apps/productivity/draw.io/draw.io-universal-25.0.2.dmg',
                           'installer_item_size': 210318,
                           'installer_type': 'copy_from_dmg',
                           'installs': [{'CFBundleIdentifier': 'com.jgraph.drawio.desktop',
                                         'CFBundleName': 'draw.io',
                                         'CFBundleShortVersionString': '25.0.2',
                                         'CFBundleVersion': '25.0.2',
                                         'minosversion': '10.15',
                                         'path': '/Applications/draw.io.app',
                                         'type': 'application',
                                         'version_comparison_key': 'CFBundleShortVersionString'}],
                           'items_to_copy': [{'destination_path': '/Applications',
                                              'source_item': 'draw.io.app'}],
                           'minimum_os_version': '10.7.0',
                           'name': 'draw.io',
                           'unattended_install': True,
                           'uninstall_method': 'remove_copied_items',
                           'uninstallable': True,
                           'version': '25.0.2'},
            'munki_repo_changed': True,
            'pkg_repo_path': '/Users/Shared/munki_repo/pkgs/apps/productivity/draw.io/draw.io-universal-25.0.2.dmg',
            'pkginfo_repo_path': '/Users/Shared/munki_repo/pkgsinfo/apps/productivity/draw.io/draw.io-25.0.2.plist'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.michalmmac.munki.draw.io/receipts/draw.io.munki-receipt-20250101-120539.plist

The following new items were imported into Munki:
    Name     Version  Catalogs  Pkginfo Path                                    Pkg Repo Path                                           Icon Repo Path
    ----     -------  --------  ------------                                    -------------                                           --------------
    draw.io  25.0.2   testing   apps/productivity/draw.io/draw.io-25.0.2.plist  apps/productivity/draw.io/draw.io-universal-25.0.2.dmg
```
